### PR TITLE
feat: add option to not record audio tracks

### DIFF
--- a/apidocs/openapi.yaml
+++ b/apidocs/openapi.yaml
@@ -334,6 +334,8 @@ components:
           type: string
         recordDeleteAfter:
           type: string
+        recordAudio:
+          type: boolean
         recordTimestampCSV:
           type: boolean
 

--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -293,6 +293,7 @@ type Conf struct {
 	RecordSegmentDuration *StringDuration `json:"recordSegmentDuration,omitempty"` // deprecated
 	RecordDeleteAfter     *StringDuration `json:"recordDeleteAfter,omitempty"`     // deprecated
 
+	RecordAudio        *bool `json:"recordAudio,omitempty"`        // deprecated
 	RecordTimestampCSV *bool `json:"recordTimestampCSV,omitempty"` // deprecated
 
 	// Path defaults
@@ -685,6 +686,9 @@ func (conf *Conf) Validate() error {
 	}
 	if conf.RecordDeleteAfter != nil {
 		conf.PathDefaults.RecordDeleteAfter = *conf.RecordDeleteAfter
+	}
+	if conf.RecordAudio != nil {
+		conf.PathDefaults.RecordAudio = *conf.RecordAudio
 	}
 	if conf.RecordTimestampCSV != nil {
 		conf.PathDefaults.RecordTimestampCSV = *conf.RecordTimestampCSV

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -57,6 +57,7 @@ func TestConfFromFile(t *testing.T) {
 			RecordPartDuration:         StringDuration(1 * time.Second),
 			RecordSegmentDuration:      3600000000000,
 			RecordDeleteAfter:          86400000000000,
+			RecordAudio:                false,
 			RecordTimestampCSV:         false,
 			OverridePublisher:          true,
 			RPICameraWidth:             1920,

--- a/internal/conf/path.go
+++ b/internal/conf/path.go
@@ -105,6 +105,7 @@ type Path struct {
 	RecordSegmentDuration StringDuration `json:"recordSegmentDuration"`
 	RecordDeleteAfter     StringDuration `json:"recordDeleteAfter"`
 
+	RecordAudio        bool `json:"recordAudio"`
 	RecordTimestampCSV bool `json:"recordTimestampCSV"`
 
 	// Authentication (deprecated)
@@ -198,6 +199,7 @@ func (pconf *Path) setDefaults() {
 	pconf.RecordPartDuration = StringDuration(1 * time.Second)
 	pconf.RecordSegmentDuration = 3600 * StringDuration(time.Second)
 	pconf.RecordDeleteAfter = 24 * 3600 * StringDuration(time.Second)
+	pconf.RecordAudio = false
 	pconf.RecordTimestampCSV = false
 
 	// Publisher source

--- a/internal/core/path.go
+++ b/internal/core/path.go
@@ -815,6 +815,7 @@ func (pa *path) startRecording() {
 		},
 		Parent: pa,
 
+		RecordAudio:        pa.conf.RecordAudio,
 		RecordTimestampCSV: pa.conf.RecordTimestampCSV,
 	}
 	pa.recorder.Initialize()

--- a/internal/recorder/format_fmp4_segment.go
+++ b/internal/recorder/format_fmp4_segment.go
@@ -119,5 +119,9 @@ func (s *formatFMP4Segment) write(track *formatFMP4Track, sample *sample, dtsDur
 		}
 	}
 
+	if !track.initTrack.Codec.IsVideo() && !s.f.ri.rec.RecordAudio {
+		return nil
+	}
+
 	return s.curPart.write(track, sample, dtsDuration)
 }

--- a/internal/recorder/recorder.go
+++ b/internal/recorder/recorder.go
@@ -27,6 +27,7 @@ type Recorder struct {
 	OnSegmentComplete OnSegmentCompleteFunc
 	Parent            logger.Writer
 
+	RecordAudio        bool
 	RecordTimestampCSV bool
 
 	restartPause time.Duration

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -470,7 +470,9 @@ pathDefaults:
   # Delete segments after this timespan.
   # Set to 0s to disable automatic deletion.
   recordDeleteAfter: 24h
-  # Record frame timestamps in a csv file.
+  # Record audio track or not, only applicable in for fmp4, mpegts always record audio
+  recordAudio: no
+  # Record frame timestamps in a csv file, only applicable for fmp4
   recordTimestampCSV: no
 
   ###############################################


### PR DESCRIPTION
The only important part is...

```
	if !track.initTrack.Codec.IsVideo() && !s.f.ri.rec.RecordAudio {
		return nil
	}
```

Note that, this exclusion is only applicable for fmp4, mpegts always record audio.